### PR TITLE
Fix turrets ignoring white list

### DIFF
--- a/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
+++ b/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
@@ -632,7 +632,7 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 		if(wl != null) {
 
 			if(e instanceof EntityPlayer) {
-				if(wl.contains(e.getDisplayName())) {
+				if(wl.contains(e.getDisplayName().getUnformattedText())) {
 					return false;
 				}
 			} else if(e instanceof EntityLiving) {

--- a/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
+++ b/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
@@ -632,7 +632,7 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 		if(wl != null) {
 
 			if(e instanceof EntityPlayer) {
-				if(wl.contains(e.getDisplayName().getUnformattedText())) {
+				if(wl.contains(e.getName())) {
 					return false;
 				}
 			} else if(e instanceof EntityLiving) {


### PR DESCRIPTION
Another tiny bug fix. Turrets now actually ignore players in the whitelist.