### PR TITLE
Fix crash with tile entity

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKAutoloader.java
+++ b/src/main/java/com/hbm/tileentity/machine/rbmk/TileEntityRBMKAutoloader.java
@@ -186,7 +186,6 @@ public class TileEntityRBMKAutoloader extends TileEntityMachineBase implements I
         stopLiftSound();
     }
 
-    @SideOnly(Side.CLIENT)
     private void stopLiftSound() {
         if (this.audioLift != null) {
             this.audioLift.stopSound();


### PR DESCRIPTION
```
// I let you down. Sorry :(

Time: 12/27/25 1:46 AM
Description: Exception ticking world entities

java.lang.NoSuchMethodError: com.hbm.tileentity.machine.rbmk.TileEntityRBMKAutoloader.stopLiftSound()V
    at com.hbm.tileentity.machine.rbmk.TileEntityRBMKAutoloader.onChunkUnload(TileEntityRBMKAutoloader.java:186)
    at net.minecraft.world.World.func_72939_s(World.java:1808)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:613)
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:767)
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:397)
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
    at java.lang.Thread.run(Thread.java:748)

No Mixin Metadata is found in the Stacktrace.


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Server thread
Stacktrace:
    at com.hbm.tileentity.machine.rbmk.TileEntityRBMKAutoloader.onChunkUnload(TileEntityRBMKAutoloader.java:186)
    at net.minecraft.world.World.func_72939_s(World.java:1808)
    at net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:613)
    
```
    
The crash is caused by a NoSuchMethodError for stopLiftSound() in TileEntityRBMKAutoloader. This happens because the method was annotated with @SideOnly(Side.CLIENT), meaning it was stripped from the server-side code, but it is called by onChunkUnload() (and invalidate()), which runs on the server as well.

I have fixed the issue by removing the @SideOnly(Side.CLIENT) annotation from stopLiftSound(). The method is safe to run on the server because audioLift is null on the server side, so the method will simply do nothing instead of crashing.