### PR TITLE
Ensure `FluidType` is non-null before generating mist effects.

### DIFF
--- a/src/main/java/com/hbm/entity/effect/EntityMist.java
+++ b/src/main/java/com/hbm/entity/effect/EntityMist.java
@@ -137,24 +137,27 @@ public class EntityMist extends Entity {
             }
         } else {
 
-            for (int i = 0; i < 2; i++) {
-                AxisAlignedBB boundingBox = this.getEntityBoundingBox();
-                double x = boundingBox.minX + rand.nextDouble() * (boundingBox.maxX - boundingBox.minX);
-                double y = boundingBox.minY + rand.nextDouble() * (boundingBox.maxY - boundingBox.minY);
-                double z = boundingBox.minZ + rand.nextDouble() * (boundingBox.maxZ - boundingBox.minZ);
+            FluidType type = this.getType();
+            if (type != null) {
+                for (int i = 0; i < 2; i++) {
+                    AxisAlignedBB boundingBox = this.getEntityBoundingBox();
+                    double x = boundingBox.minX + rand.nextDouble() * (boundingBox.maxX - boundingBox.minX);
+                    double y = boundingBox.minY + rand.nextDouble() * (boundingBox.maxY - boundingBox.minY);
+                    double z = boundingBox.minZ + rand.nextDouble() * (boundingBox.maxZ - boundingBox.minZ);
 
 
-                NBTTagCompound fx = new NBTTagCompound();
-                fx.setString("type", "tower");
-                fx.setFloat("lift", 0.5F);
-                fx.setFloat("base", 0.75F);
-                fx.setFloat("max", 2F);
-                fx.setInteger("life", 50 + world.rand.nextInt(10));
-                fx.setInteger("color", this.getType().getColor());
-                fx.setDouble("posX", x);
-                fx.setDouble("posY", y);
-                fx.setDouble("posZ", z);
-                MainRegistry.proxy.effectNT(fx);
+                    NBTTagCompound fx = new NBTTagCompound();
+                    fx.setString("type", "tower");
+                    fx.setFloat("lift", 0.5F);
+                    fx.setFloat("base", 0.75F);
+                    fx.setFloat("max", 2F);
+                    fx.setInteger("life", 50 + world.rand.nextInt(10));
+                    fx.setInteger("color", type.getColor());
+                    fx.setDouble("posX", x);
+                    fx.setDouble("posY", y);
+                    fx.setDouble("posZ", z);
+                    MainRegistry.proxy.effectNT(fx);
+                }
             }
         }
     }
@@ -368,4 +371,3 @@ public class EntityMist extends Entity {
         NULL
     }
 }
-


### PR DESCRIPTION
```
-- Head --
Thread: Client thread
Stacktrace:
	at com.hbm.entity.effect.EntityMist.func_70030_z(EntityMist.java:105)
	at net.minecraft.entity.Entity.func_70071_h_(Entity.java:389)
	at net.minecraft.world.World.func_72866_a(World.java:1996)
	at net.minecraft.world.World.func_72870_g(World.java:1958)

-- Entity being ticked --
Details:
	Entity Type: hbm:entity_mist (com.hbm.entity.effect.EntityMist)
	Entity ID: 12455
	Entity Name: entity.entity_mist.name
	Entity's Exact location: redacted
	Entity's Block location: redacted
	Entity's Momentum: 0.00, -0.08, 0.00
	Entity's Passengers: []
	Entity's Vehicle: ~~ERROR~~ NullPointerException: null
Stacktrace:
	at net.minecraft.world.World.func_72939_s(World.java:1762)
```


The crash is a `NullPointerException` occurring in `EntityMist.onEntityUpdate`. The stack trace specifically points to `EntityMist.func_70030_z` (which maps to `onEntityUpdate` in MCP mappings) at line 105.

### Relevant Code (EntityMist.java)
```java
105: fx.setInteger("color", this.getType().getColor());
```

This line is located inside an `else` block of `if (!world.isRemote)`, meaning it executes **on the client side**.

### Root Cause
The issue arises because `this.getType()` can return `null`, leading to an NPE when calling `.getColor()`.

The `getType()` method retrieves the fluid type based on a data parameter:
```java
public FluidType getType() {
    return Fluids.fromID(this.dataManager.get(TYPE));
}
```

If `Fluids.fromID(...)` returns `null` — for example:
- The stored ID is invalid (e.g., 0, which may map to `null`),
- Or the data parameter hasn't been synced to the client yet —

then `getType()` returns `null`, and the subsequent `.getColor()` call crashes the client.

### Fix Implemented
Added a null check for the fluid type before using it in the client-side update loop:

```java
FluidType type = this.getType();
if (type != null) {
    for (int i = 0; i < 2; i++) {
        // ...
        fx.setInteger("color", type.getColor());
        // ...
    }
}
```

This prevents the crash when the fluid type is not yet available or is invalid on the client, allowing the entity to continue updating safely until the data is properly synced.