### PR TITLE
Added OpenComputers Support to the Geiger Counter

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityGeiger.java
@@ -1,17 +1,23 @@
 package com.hbm.tileentity.machine;
 
+import com.hbm.handler.CompatHandler;
 import com.hbm.handler.radiation.ChunkRadiationManager;
 import com.hbm.interfaces.AutoRegister;
 import com.hbm.lib.HBMSoundHandler;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ITickable;
 import net.minecraft.util.SoundCategory;
-
+import net.minecraftforge.fml.common.Optional;
 import java.util.ArrayList;
 import java.util.List;
 
+@Optional.InterfaceList({@Optional.Interface(iface = "li.cil.oc.api.network.SimpleComponent", modid = "opencomputers")})
 @AutoRegister
-public class TileEntityGeiger extends TileEntity implements ITickable {
+public class TileEntityGeiger extends TileEntity implements ITickable, SimpleComponent, CompatHandler.OCComponent {
 
 	int timer = 0;
     double ticker = 0;
@@ -56,4 +62,32 @@ public class TileEntityGeiger extends TileEntity implements ITickable {
     public double check() {
         return ChunkRadiationManager.proxy.getRadiation(world, pos);
     }
+
+	// OpenComputers Integration
+	@Optional.Method(modid = "opencomputers")
+	public String getComponentName() {
+		return "ntm_geiger";
+	}
+
+	@Callback(direct = true)
+	@Optional.Method(modid = "opencomputers")
+	public Object[] getRads(Context context, Arguments args) {
+		return new Object[] {check()};
+	}
+
+	@Optional.Method(modid = "opencomputers")
+	public String[] methods() {
+		return new String[]{
+				"getRads"
+		};
+	}
+
+	@Optional.Method(modid = "opencomputers")
+	public Object[] invoke(String method, Context context, Arguments args) throws Exception {
+		switch (method) {
+			case ("getRads"):
+				return getRads(context, args);
+		}
+		throw new NoSuchMethodException();
+	}
 }


### PR DESCRIPTION
This PR adds OpenComputers Support for the Geiger Counter since it was missing

I used the OpenComputers Implementation in `TileEntityReactorZirnox.java` as a Reference, the Component Name and Method Name were taken as a reference from the HBM 1.7 Code

Simple Test using a Radioactive Barrel and then breaking it showed the OpenComputers Support to work fine: 
<img width="455" height="608" alt="image" src="https://github.com/user-attachments/assets/ae6f5298-b305-47be-9f5b-ef24292cd100" />
