### PR TITLE
Custom siren track api and config

### DIFF
--- a/src/main/java/com/hbm/blocks/PlantEnums.java
+++ b/src/main/java/com/hbm/blocks/PlantEnums.java
@@ -2,7 +2,7 @@ package com.hbm.blocks;
 
 public class PlantEnums {
 
-    public static enum EnumDeadPlantType {
+    public enum EnumDeadPlantType {
         GENERIC,
         GRASS,
         FLOWER,
@@ -12,7 +12,7 @@ public class PlantEnums {
         public static final EnumDeadPlantType[] VALUES = values();
     }
 
-    public static enum EnumFlowerPlantType {
+    public enum EnumFlowerPlantType {
         FOXGLOVE,
         HEMP,
         MUSTARD_WILLOW_0(true),
@@ -28,7 +28,7 @@ public class PlantEnums {
         EnumFlowerPlantType(){ this.needsOil = false;}
     }
 
-    public static enum EnumTallPlantType {
+    public enum EnumTallPlantType {
         HEMP_LOWER(false),
         HEMP_UPPER(false),
         MUSTARD_WILLOW_2_LOWER,

--- a/src/main/java/com/hbm/blocks/machine/MachineSiren.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineSiren.java
@@ -16,6 +16,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.common.network.internal.FMLNetworkHandler;
 
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
 public class MachineSiren extends BlockContainer {
 
 	public MachineSiren(Material materialIn, String s) {
@@ -52,7 +56,8 @@ public class MachineSiren extends BlockContainer {
 	}
 
 	@Override
-	public EnumBlockRenderType getRenderType(IBlockState state) {
+    @SuppressWarnings("deprecation")
+	public @Nonnull EnumBlockRenderType getRenderType(IBlockState state) {
 		return EnumBlockRenderType.MODEL;
 	}
 	

--- a/src/main/java/com/hbm/config/BedrockOreJsonConfig.java
+++ b/src/main/java/com/hbm/config/BedrockOreJsonConfig.java
@@ -10,7 +10,7 @@ import java.util.*;
 
 public class BedrockOreJsonConfig {
 
-	public static final String bedrockOreJsonConfigFile = "hbm_bedrock_ores.json";
+	public static final String FILENAME = "hbm_bedrock_ores.json";
 
 	public static HashMap<Integer, HashSet<String>> dimOres = new HashMap<>();
 	public static HashMap<Integer, Boolean> dimWhiteList = new HashMap<>();
@@ -20,6 +20,7 @@ public class BedrockOreJsonConfig {
 		if(!loadFromJson()){
 			clear();
 			setDefaults();
+            if (JsonConfig.isFileNonexistent(FILENAME)) writeToJson();
 		}
 	}
 
@@ -110,9 +111,10 @@ public class BedrockOreJsonConfig {
 	}
 
 	// foont: who would ever overwrite config if it's wrong. I don't see a reason to have this, in release mod definitely
+    // vidarin: this is needed to generate the file the first time minecraft loads
 	public static void writeToJson(){
 		try {
-			JsonWriter writer = JsonConfig.startWriting(bedrockOreJsonConfigFile);
+			JsonWriter writer = JsonConfig.startWriting(FILENAME);
 			writer.name("dimConfig").beginArray();
 			for(Integer dimID : dimOres.keySet()){
 				writer.beginObject();
@@ -128,13 +130,13 @@ public class BedrockOreJsonConfig {
 			writer.endArray();
 			JsonConfig.stopWriting(writer);
 		} catch(Exception ex) {
-			ex.printStackTrace();
+			MainRegistry.logger.error(ex.getStackTrace());
 		}
 	}
 
 	public static boolean loadFromJson() {
 		try {
-			JsonObject reader = JsonConfig.startReading(bedrockOreJsonConfigFile);
+			JsonObject reader = JsonConfig.startReading(FILENAME);
 
 			if(reader == null || !reader.has("dimConfig")) return false;
 
@@ -166,7 +168,7 @@ public class BedrockOreJsonConfig {
 			return true;
 		} catch(Exception ex) {
 			MainRegistry.logger.error("Loading the bedrock ore config resulted in an error. Falling back to defaults.");
-			ex.printStackTrace();
+            MainRegistry.logger.error(ex.getStackTrace());
 			return false;
 		}
 	}

--- a/src/main/java/com/hbm/config/CassetteJsonConfig.java
+++ b/src/main/java/com/hbm/config/CassetteJsonConfig.java
@@ -1,0 +1,103 @@
+package com.hbm.config;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.stream.JsonWriter;
+import com.hbm.items.machine.ItemCassette;
+import com.hbm.main.MainRegistry;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.SoundEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+
+import java.util.Locale;
+
+/**
+ * How to create a cassette element:
+ * <pre>{@code
+ *     {
+ *         "name": "Name of track",
+ *         "sound": "modid:sound.name", //Custom sounds can be added to any mod via resource packs (both as a file and in sounds.json), and hbm will try to register it
+ *         "type": "LOOP", //Can also be PASS or SOUND
+ *         "color": "00FF75", //Can also be a base-10 integer
+ *         "volume": 100 //Optional; default is 50
+ *     }
+ * }</pre>
+ */
+public class CassetteJsonConfig {
+    public static final String FILENAME = "hbm_siren_cassettes.json";
+
+    public static void init() {
+        if (!tryRead() && JsonConfig.isFileNonexistent(FILENAME)) {
+            try {
+                JsonWriter writer = JsonConfig.startWriting(FILENAME);
+                writer.name("cassetteConfig").beginArray().endArray();
+                JsonConfig.stopWriting(writer);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private static boolean tryRead() {
+        try {
+            JsonObject reader = JsonConfig.startReading(FILENAME);
+
+            if (reader == null || !reader.has("cassetteConfig")) return false;
+            JsonArray entries = reader.getAsJsonArray("cassetteConfig");
+            for (JsonElement entry : entries) {
+                if (entry == null || !entry.isJsonObject()) continue;
+                JsonObject obj = entry.getAsJsonObject();
+
+                if (!obj.has("name")) continue;
+                String name = obj.get("name").getAsString();
+
+                if (!obj.has("sound")) continue;
+                ResourceLocation soundLocation = new ResourceLocation(obj.get("sound").getAsString());
+                SoundEvent sound = SoundEvent.REGISTRY.getObject(soundLocation);
+                if (sound == null) sound = tryRegisterSound(soundLocation);
+
+                if (!obj.has("type")) continue;
+                ItemCassette.SoundType type = switch (obj.get("type").getAsString().toLowerCase(Locale.ROOT)) {
+                    case "loop" -> ItemCassette.SoundType.LOOP;
+                    case "pass" -> ItemCassette.SoundType.PASS;
+                    case "sound" -> ItemCassette.SoundType.SOUND;
+                    default -> null;
+                };
+                if (type == null) continue;
+
+                if (!obj.has("color")) continue;
+                int color = 0;
+                if (obj.get("color").isJsonPrimitive()) {
+                    JsonPrimitive primitive = obj.get("color").getAsJsonPrimitive();
+                    if (primitive.isNumber()) color = primitive.getAsInt();
+                    else if (primitive.isString()) color = Integer.parseInt(primitive.getAsString(), 16);
+                }
+
+                int volume;
+                if (!obj.has("volume")) volume = 50;
+                else volume = obj.get("volume").getAsInt();
+
+                ItemCassette.TrackType.register(name, sound, type, color, volume);
+            }
+
+            return true;
+        } catch (Exception e) {
+            MainRegistry.logger.error("Error while reading siren cassette config.");
+            MainRegistry.logger.error(e.getStackTrace());
+            return false;
+        }
+    }
+
+    public static SoundEvent tryRegisterSound(ResourceLocation location) {
+        try {
+            SoundEvent e = new SoundEvent(location);
+            e.setRegistryName(location.getPath());
+            ForgeRegistries.SOUND_EVENTS.register(e);
+            return e;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not find nor register siren sound at location " + location, e);
+        }
+    }
+}

--- a/src/main/java/com/hbm/config/JsonConfig.java
+++ b/src/main/java/com/hbm/config/JsonConfig.java
@@ -10,12 +10,15 @@ import java.io.FileReader;
 import java.io.FileWriter;
 
 public class JsonConfig {
-
 	public static final Gson gson = new Gson();
-	
+
 	private static File getFile(String filename){
 		return new File(MainRegistry.proxy.getDataDir().getPath() + "/config/hbm" + File.separatorChar + filename);
 	}
+
+    public static boolean isFileNonexistent(String filename) {
+        return !getFile(filename).exists();
+    }
 
 	public static JsonWriter startWriting(String filename){
 		try{
@@ -23,7 +26,7 @@ public class JsonConfig {
 			writer.setIndent("  ");
 			writer.beginObject();
 			return writer;
-		} catch(Exception ex) { }
+		} catch(Exception _) { }
 		return null;
 	}
 
@@ -31,7 +34,7 @@ public class JsonConfig {
 		try{
 			writer.endObject();
 			writer.close();
-		} catch(Exception ex) {	}
+		} catch(Exception _) {	}
 	}
 
 	public static JsonObject startReading(String filename){
@@ -40,7 +43,7 @@ public class JsonConfig {
 			if(file.exists())
 				return gson.fromJson(new FileReader(file), JsonObject.class);
 			return null;
-		} catch(Exception ex) { }
+		} catch(Exception _) { }
 		return null;
 	}
 }

--- a/src/main/java/com/hbm/inventory/gui/GUIMachineSiren.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIMachineSiren.java
@@ -37,7 +37,7 @@ public class GUIMachineSiren extends GuiContainer {
 		this.fontRenderer.drawString(I18n.format("container.inventory"), 8, this.ySize - 96 + 2, 4210752);
 		
 		//Draw record meta here//
-		if(!siren.getCurrentType().name().equals(TrackType.NULL.name())) {
+		if(!siren.getCurrentType().getTrackTitle().equals(TrackType.NULL.getTrackTitle())) {
 			int color = siren.getCurrentType().getColor();
 			this.fontRenderer.drawString(siren.getCurrentType().getTrackTitle(), 46, 28, color);
 			this.fontRenderer.drawString("Type: " + siren.getCurrentType().getType().name(), 46, 40, color);

--- a/src/main/java/com/hbm/inventory/gui/GUIScreenTemplateFolder.java
+++ b/src/main/java/com/hbm/inventory/gui/GUIScreenTemplateFolder.java
@@ -65,7 +65,7 @@ public class GUIScreenTemplateFolder extends GuiScreen {
 			for(ItemStack i : ItemStamp.stamps.get(ItemStamp.StampType.WIRE)) allStacks.add(i.copy());
 			for(ItemStack i : ItemStamp.stamps.get(ItemStamp.StampType.CIRCUIT)) allStacks.add(i.copy());
 			// Tracks
-			for (int i = 1; i < ItemCassette.TrackType.VALUES.length; i++) {
+			for (int i = 1; i < ItemCassette.TrackType.VALUES.size(); i++) {
 				allStacks.add(new ItemStack(ModItems.siren_track, 1, i));
 			}
 		}

--- a/src/main/java/com/hbm/items/machine/ItemCassette.java
+++ b/src/main/java/com/hbm/items/machine/ItemCassette.java
@@ -2,6 +2,9 @@ package com.hbm.items.machine;
 
 import com.hbm.items.ModItems;
 import com.hbm.lib.HBMSoundHandler;
+import com.hbm.main.MainRegistry;
+import it.unimi.dsi.fastutil.ints.Int2ObjectArrayMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.client.util.ITooltipFlag;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
@@ -11,66 +14,85 @@ import net.minecraft.util.SoundEvent;
 import net.minecraft.world.World;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
 
 public class ItemCassette extends Item {
+	@SuppressWarnings("unused")
+    public static class TrackType {
+        public static final Int2ObjectMap<TrackType> VALUES = new Int2ObjectArrayMap<>(20);
 
-	public enum TrackType {
+		public static final TrackType NULL = new TrackType(" ", null, SoundType.SOUND, 0, 0, 0);
+        public static final TrackType HATCH = new TrackType("Hatch Siren", HBMSoundHandler.alarmHatch, SoundType.LOOP, 3358839, 250, 1);
+        public static final TrackType AUTOPILOT = new TrackType("Autopilot Disconnected", HBMSoundHandler.alarmAutopilot, SoundType.LOOP, 11908533, 50, 2);
+        public static final TrackType AMS_SIREN = new TrackType("AMS Siren", HBMSoundHandler.alarmAMSSiren, SoundType.LOOP, 15055698, 50, 3);
+        public static final TrackType BLAST_DOOR = new TrackType("Blast Door Alarm", HBMSoundHandler.alarmBlastDoor, SoundType.LOOP, 11665408, 50, 4);
+        public static final TrackType APC_LOOP = new TrackType("APC Siren", HBMSoundHandler.alarmAPCLoop, SoundType.LOOP, 3565216, 50, 5);
+        public static final TrackType KLAXON = new TrackType("Klaxon", HBMSoundHandler.alarmKlaxon, SoundType.LOOP, 8421504, 50, 6);
+        public static final TrackType KLAXON_A = new TrackType("Vault Door Alarm", HBMSoundHandler.alarmFoKlaxonA, SoundType.LOOP, 0x8c810b, 50, 7);
+        public static final TrackType KLAXON_B = new TrackType("Security Alert", HBMSoundHandler.alarmFoKlaxonB, SoundType.LOOP, 0x76818e, 50, 8);
+        public static final TrackType SIREN = new TrackType("Standard Siren", HBMSoundHandler.alarmRegular, SoundType.LOOP, 6684672, 100, 9);
+        public static final TrackType CLASSIC = new TrackType("Classic Siren", HBMSoundHandler.alarmClassic, SoundType.LOOP, 0xc0cfe8, 100, 10);
+        public static final TrackType BANK_ALARM = new TrackType("Bank Alarm", HBMSoundHandler.alarmBank, SoundType.LOOP, 3572962, 100, 11);
+        public static final TrackType BEEP_SIREN = new TrackType("Beep Siren", HBMSoundHandler.alarmBeep, SoundType.LOOP, 13882323, 100, 12);
+        public static final TrackType CONTAINER_ALARM = new TrackType("Container Alarm", HBMSoundHandler.alarmContainer, SoundType.LOOP, 14727839, 100, 13);
+        public static final TrackType SWEEP_SIREN = new TrackType("Sweep Siren", HBMSoundHandler.alarmSweep, SoundType.LOOP, 15592026, 500, 14);
+        public static final TrackType STRIDER_SIREN = new TrackType("Missile Silo Siren", HBMSoundHandler.alarmStrider, SoundType.LOOP, 11250586, 500, 15);
+        public static final TrackType AIR_RAID = new TrackType("Air Raid Siren", HBMSoundHandler.alarmAirRaid, SoundType.LOOP, 0xDF3795, 500, 16);
+        public static final TrackType NOSTROMO_SIREN = new TrackType("Nostromo Self Destruct", HBMSoundHandler.alarmNostromo, SoundType.LOOP, 0x5dd800, 100, 17);
+        public static final TrackType EAS_ALARM = new TrackType("EAS Alarm Screech", HBMSoundHandler.alarmEas, SoundType.LOOP, 0xb3a8c1, 50, 18);
+        public static final TrackType APC_PASS = new TrackType("APC Pass", HBMSoundHandler.alarmAPCPass, SoundType.PASS, 3422163, 50, 19);
+        public static final TrackType RAZORTRAIN = new TrackType("Razortrain Horn", HBMSoundHandler.alarmRazorTrain, SoundType.SOUND, 7819501, 250, 20);
 
-		NULL(" ", null, SoundType.SOUND, 0, 0), HATCH("Hatch Siren", HBMSoundHandler.alarmHatch, SoundType.LOOP, 3358839, 250), ATUOPILOT("Autopilot Disconnected", HBMSoundHandler.alarmAutopilot, SoundType.LOOP, 11908533, 50), AMS_SIREN("AMS Siren", HBMSoundHandler.alarmAMSSiren, SoundType.LOOP, 15055698, 50), BLAST_DOOR("Blast Door Alarm", HBMSoundHandler.alarmBlastDoor, SoundType.LOOP, 11665408, 50), APC_LOOP("APC Siren", HBMSoundHandler.alarmAPCLoop, SoundType.LOOP, 3565216, 50), KLAXON("Klaxon", HBMSoundHandler.alarmKlaxon, SoundType.LOOP, 8421504, 50), KLAXON_A("Vault Door Alarm", HBMSoundHandler.alarmFoKlaxonA, SoundType.LOOP, 0x8c810b, 50), KLAXON_B("Security Alert", HBMSoundHandler.alarmFoKlaxonB, SoundType.LOOP, 0x76818e, 50), SIREN("Standard Siren", HBMSoundHandler.alarmRegular, SoundType.LOOP, 6684672, 100), CLASSIC("Classic Siren", HBMSoundHandler.alarmClassic, SoundType.LOOP, 0xc0cfe8, 100), BANK_ALARM("Bank Alarm", HBMSoundHandler.alarmBank, SoundType.LOOP, 3572962,
-				100), BEEP_SIREN("Beep Siren", HBMSoundHandler.alarmBeep, SoundType.LOOP, 13882323, 100), CONTAINER_ALARM("Container Alarm", HBMSoundHandler.alarmContainer, SoundType.LOOP, 14727839, 100), SWEEP_SIREN("Sweep Siren", HBMSoundHandler.alarmSweep, SoundType.LOOP, 15592026, 500), STRIDER_SIREN("Missile Silo Siren", HBMSoundHandler.alarmStrider, SoundType.LOOP, 11250586, 500), AIR_RAID("Air Raid Siren", HBMSoundHandler.alarmAirRaid, SoundType.LOOP, 0xDF3795, 500), NOSTROMO_SIREN("Nostromo Self Destruct", HBMSoundHandler.alarmNostromo, SoundType.LOOP, 0x5dd800, 100), EAS_ALARM("EAS Alarm Screech", HBMSoundHandler.alarmEas, SoundType.LOOP, 0xb3a8c1, 50), APC_PASS("APC Pass", HBMSoundHandler.alarmAPCPass, SoundType.PASS, 3422163, 50), RAZORTRAIN("Razortrain Horn", HBMSoundHandler.alarmRazorTrain, SoundType.SOUND, 7819501, 250);
-
-        public static final TrackType[] VALUES = values();
+        private static final AtomicInteger nextId = new AtomicInteger(21); // AtomicInteger to make sure no id collisions happen because of threading (i know its overkill but its not like this is a major performance bottleneck)
 
 		// Name of the track shown in GUI
-		private String title;
+		private final String title;
 		// Location of the sound
-		private SoundEvent location;
+		private final SoundEvent location;
 		// Sound type, whether the sound should be repeated or not
-		private SoundType type;
+		private final SoundType type;
 		// Color of the cassette
-		private int color;
+		private final int color;
 		// Range where the sound can be heard
-		private int volume;
+		private final int volume;
 
-		private TrackType(String name, SoundEvent loc, SoundType sound, int msa, int intensity) {
-			title = name;
-			location = loc;
-			type = sound;
-			color = msa;
-			volume = intensity;
+        private final int id;
+
+        private TrackType(String name, SoundEvent loc, SoundType sound, int color, int volume, int id) {
+			this.title = name;
+			this.location = loc;
+			this.type = sound;
+			this.color = color;
+			this.volume = volume;
+            this.id = id;
+            //Vidarin: If some ee user manages to break things even though it should be impossible (or my code is bad)
+            if (VALUES.containsKey(id)) MainRegistry.logger.error("ID collision when registering siren tracks! (id: {}, old track: \"{}\", new track: \"{}\")", id, VALUES.get(id).title, name);
+            VALUES.put(id, this);
 		}
 
-		public String getTrackTitle() {
-			return title;
-		}
+        public static TrackType register(String name, SoundEvent loc, SoundType sound, int color, int volume) {
+            return new TrackType(name, loc, sound, color, volume, nextId.getAndIncrement());
+        }
 
-		public SoundEvent getSoundLocation() {
-			return location;
-		}
+		public String getTrackTitle() { return title; }
+		public SoundEvent getSoundLocation() { return location; }
+		public SoundType getType() { return type; }
+		public int getColor() { return color; }
+		public int getVolume() { return volume; }
+        public int getId() { return id; }
 
-		public SoundType getType() {
-			return type;
-		}
-
-		public int getColor() {
-			return color;
-		}
-
-		public int getVolume() {
-			return volume;
-		}
-
-		public static TrackType getEnum(int i) {
-			if(i < TrackType.VALUES.length)
-				return TrackType.VALUES[i];
+		public static TrackType byIndex(int i) {
+			if (i < VALUES.size())
+				return VALUES.get(i);
 			else
-				return TrackType.NULL;
+				return NULL;
 		}
-	};
+	}
 
 	public enum SoundType {
 		LOOP, PASS, SOUND;
-	};
+	}
 
 	public ItemCassette(String s) {
 		this.setTranslationKey(s);
@@ -84,7 +106,7 @@ public class ItemCassette extends Item {
 	@Override
 	public void getSubItems(CreativeTabs tab, NonNullList<ItemStack> items) {
 		if(tab == this.getCreativeTab() || tab == CreativeTabs.SEARCH) {
-			for(int i = 1; i < TrackType.VALUES.length; ++i) {
+			for(int i = 1; i < TrackType.VALUES.size(); ++i) {
 				items.add(new ItemStack(this, 1, i));
 			}
 		}
@@ -99,14 +121,14 @@ public class ItemCassette extends Item {
 		tooltip.add("");
 
 		tooltip.add("Siren sound cassette:");
-		tooltip.add("   Name: " + TrackType.getEnum(stack.getItemDamage()).getTrackTitle());
-		tooltip.add("   Type: " + TrackType.getEnum(stack.getItemDamage()).getType().name());
-		tooltip.add("   Volume: " + TrackType.getEnum(stack.getItemDamage()).getVolume());
+		tooltip.add("   Name: " + TrackType.byIndex(stack.getItemDamage()).getTrackTitle());
+		tooltip.add("   Type: " + TrackType.byIndex(stack.getItemDamage()).getType().name());
+		tooltip.add("   Volume: " + TrackType.byIndex(stack.getItemDamage()).getVolume());
 	}
 
 	public static TrackType getType(ItemStack stack) {
 		if(stack != null && stack.getItem() instanceof ItemCassette)
-			return TrackType.getEnum(stack.getItemDamage());
+			return TrackType.byIndex(stack.getItemDamage());
 		else
 			return TrackType.NULL;
 	}

--- a/src/main/java/com/hbm/main/MainRegistry.java
+++ b/src/main/java/com/hbm/main/MainRegistry.java
@@ -153,6 +153,7 @@ public class MainRegistry {
         StructureConfig.loadFromConfig(config);
         reloadCompatConfig();
         BedrockOreJsonConfig.init();
+        CassetteJsonConfig.init();
         config.save();
     }
 
@@ -172,10 +173,10 @@ public class MainRegistry {
             IMCHandler handler = IMCHandler.getHandler(message.key);
 
             if (handler != null) {
-                MainRegistry.logger.info("Received IMC of type >" + message.key + "< from " + message.getSender() + "!");
+                MainRegistry.logger.info("Received IMC of type >{}< from {}!", message.key, message.getSender());
                 handler.process(message);
             } else {
-                MainRegistry.logger.error("Could not process unknown IMC type \"" + message.key + "\"");
+                MainRegistry.logger.error("Could not process unknown IMC type \"{}\"", message.key);
             }
         }
     }
@@ -192,9 +193,8 @@ public class MainRegistry {
         if (generalOverride > 0 && generalOverride < 19) {
             polaroidID = generalOverride;
         } else {
-            polaroidID = rand.nextInt(18) + 1;
-            while (polaroidID == 4 || polaroidID == 9)
-                polaroidID = rand.nextInt(18) + 1;
+            do polaroidID = rand.nextInt(18) + 1;
+            while (polaroidID == 4 || polaroidID == 9);
         }
 
         configDir = event.getModConfigurationDirectory();

--- a/src/main/java/com/hbm/main/client/NTMClientRegistry.java
+++ b/src/main/java/com/hbm/main/client/NTMClientRegistry.java
@@ -89,7 +89,7 @@ public class NTMClientRegistry {
         };
         evt.getItemColors().registerItemColorHandler((ItemStack stack, int tintIndex) -> {
             if (tintIndex == 1) {
-                int j = ItemCassette.TrackType.getEnum(stack.getItemDamage()).getColor();
+                int j = ItemCassette.TrackType.byIndex(stack.getItemDamage()).getColor();
                 if (j < 0) j = 0xFFFFFF;
                 return j;
             }
@@ -366,7 +366,7 @@ public class NTMClientRegistry {
                 ModelLoader.setCustomModelResourceLocation(item, i, new ModelResourceLocation(item.getRegistryName(), "inventory"));
             }
         } else if (item == ModItems.siren_track) {
-            for (int i = 0; i < ItemCassette.TrackType.VALUES.length; i++) {
+            for (int i = 0; i < ItemCassette.TrackType.VALUES.size(); i++) {
                 ModelLoader.setCustomModelResourceLocation(item, i, new ModelResourceLocation(item.getRegistryName(), "inventory"));
             }
         } else if (item == ModItems.ingot_u238m2) {

--- a/src/main/java/com/hbm/packet/toclient/TESirenPacket.java
+++ b/src/main/java/com/hbm/packet/toclient/TESirenPacket.java
@@ -85,7 +85,7 @@ public class TESirenPacket implements IMessage {
                     return;
                 }
 
-                TrackType track = TrackType.getEnum(m.id);
+                TrackType track = TrackType.byIndex(m.id);
                 SoundEvent soundLocation = track.getSoundLocation();
 
                 if (soundLocation == null || track == TrackType.NULL) {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSiren.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineSiren.java
@@ -26,18 +26,17 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
 @AutoRegister
+@ParametersAreNonnullByDefault
 public class TileEntityMachineSiren extends TileEntity implements ITickable, IControllable, IGUIProvider {
 
 	public ItemStackHandler inventory;
-
-	///private static final int[] slots_top = new int[] { 0 };
-	///private static final int[] slots_bottom = new int[] { 0 };
-	//private static final int[] slots_side = new int[] { 0 };
 
 	public boolean lock = false;
 	public boolean ctrlActive = false;
@@ -59,7 +58,7 @@ public class TileEntityMachineSiren extends TileEntity implements ITickable, ICo
 	}
 
 	public boolean hasCustomInventoryName() {
-		return this.customName != null && this.customName.length() > 0;
+		return this.customName != null && !this.customName.isEmpty();
 	}
 
 	public void setCustomName(String name) {
@@ -83,7 +82,7 @@ public class TileEntityMachineSiren extends TileEntity implements ITickable, ICo
 	}
 
 	@Override
-	public NBTTagCompound writeToNBT(NBTTagCompound compound) {
+	public @NotNull NBTTagCompound writeToNBT(NBTTagCompound compound) {
 		compound.setTag("inventory", inventory.serializeNBT());
 		return super.writeToNBT(compound);
 	}
@@ -91,9 +90,9 @@ public class TileEntityMachineSiren extends TileEntity implements ITickable, ICo
 	@Override
 	public void update() {
 		if(!world.isRemote) {
-			int id = Arrays.asList(TrackType.VALUES).indexOf(getCurrentType());
+			int id = getCurrentType().getId();
 
-			if(getCurrentType().name().equals(TrackType.NULL.name())) {
+			if(getCurrentType().getTrackTitle().equals(TrackType.NULL.getTrackTitle())) {
 				PacketDispatcher.wrapper.sendToDimension(new TESirenPacket(pos.getX(), pos.getY(), pos.getZ(), id, false), world.provider.getDimension());
 				return;
 			}
@@ -120,19 +119,19 @@ public class TileEntityMachineSiren extends TileEntity implements ITickable, ICo
 
 	public TrackType getCurrentType() {
 		if(inventory.getStackInSlot(0).getItem() instanceof ItemCassette) {
-			return TrackType.getEnum(inventory.getStackInSlot(0).getItemDamage());
+			return TrackType.byIndex(inventory.getStackInSlot(0).getItemDamage());
 		}
 
 		return TrackType.NULL;
 	}
 
 	@Override
-	public boolean hasCapability(Capability<?> capability, EnumFacing facing) {
+	public boolean hasCapability(Capability<?> capability, @Nullable EnumFacing facing) {
 		return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
 	}
 
 	@Override
-	public <T> T getCapability(Capability<T> capability, EnumFacing facing) {
+	public <T> T getCapability(Capability<T> capability, @Nullable EnumFacing facing) {
 		return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ? CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(inventory) : super.getCapability(capability, facing);
 	}
 
@@ -145,7 +144,7 @@ public class TileEntityMachineSiren extends TileEntity implements ITickable, ICo
 
 	@Override
 	public List<String> getInEvents(){
-		return Arrays.asList("siren_set_state");
+		return List.of("siren_set_state");
 	}
 
 	@Override


### PR DESCRIPTION
Addons can now register their own siren tracks using `ItemCassette$TrackType.register()`, and a new config file "hbm_siren_cassettes.cfg" has been added where you can add tracks without making a whole addon. It also allows adding custom sound files via a resource pack and loading those.

This is an "example" of a new track added via config:
```
      {
          "name": "Name of track",
          "sound": "modid:sound.name", //Custom sounds can be added to any mod via resource packs (both as a file and in sounds.json), and hbm will try to register it
          "type": "LOOP", //Can also be PASS or SOUND
          "color": "00FF75", //Can also be a base-10 integer
          "volume": 100 //Optional; default is 50
      }
 ```