### PR TITLE
Please Review Network Disconnection Bugs

### DIFF
--- a/src/main/java/com/hbm/core/FMLNetworkHook.java
+++ b/src/main/java/com/hbm/core/FMLNetworkHook.java
@@ -108,6 +108,8 @@ public final class FMLNetworkHook {
                     });
                     return;
                 }
+
+                payload.retain();
                 List<Packet<INetHandlerPlayClient>> parts = fmlProxyPacketToS3FPackets(pkt);
                 int last = parts.size() - 1;
 


### PR DESCRIPTION
Please review this bug which can cause disconnect on login and some changes to the network code that seem to fix it.

[03:27:34] [Netty Epoll Server IO #10/ERROR] [FML]: NetworkDispatcher exception
io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release0(AbstractReferenceCountedByteBuf.java:101) ~[AbstractReferenceCountedByteBuf.class:?]
	at io.netty.buffer.AbstractReferenceCountedByteBuf.release(AbstractReferenceCountedByteBuf.java:89) ~[AbstractReferenceCountedByteBuf.class:?]
	at net.minecraft.network.PacketBuffer.release(PacketBuffer.java:1339) ~[gy.class:?]
	at com.hbm.core.FMLNetworkHook.networkDispatcherWrite(FMLNetworkHook.java:126) ~[NTM-CE-1.12.2-2.0.0.0.jar:?]
	at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.write(NetworkDispatcher.java) ~[NetworkDispatcher.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738) ~[AbstractChannelHandlerContext.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:801) ~[AbstractChannelHandlerContext.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:814) ~[AbstractChannelHandlerContext.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:794) ~[AbstractChannelHandlerContext.class:?]
	at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:831) ~[AbstractChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1032) ~[DefaultChannelPipeline.class:?]
	at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:296) ~[AbstractChannel.class:?]
	at net.minecraft.network.NetworkManager$4.run(NetworkManager.java:245) [gw$4.class:?]
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [AbstractEventExecutor.class:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403) [SingleThreadEventExecutor.class:?]
	at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304) [EpollEventLoop.class:?]
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) [SingleThreadEventExecutor$5.class:?]
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_472]
[03:27:34] [Server thread/INFO] [net.minecraft.network.NetHandlerPlayServer]: kdeeks lost connection: Internal Exception: io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1
[03:27:34] [Server thread/INFO] [net.minecraft.server.dedicated.DedicatedServer]: kdeeks left the game


And

NetworkDispatcher exception


io.netty.util.IllegalReferenceCountException: refCnt: 0

    at io.netty.buffer.AbstractByteBuf.ensureAccessible(AbstractByteBuf.java:1408) ~[AbstractByteBuf.class:?]

    at io.netty.buffer.UnpooledHeapByteBuf.capacity(UnpooledHeapByteBuf.java:114) ~[UnpooledHeapByteBuf.class:?]

    at io.netty.buffer.AbstractUnpooledSlicedByteBuf.checkSliceOutOfBounds(AbstractUnpooledSlicedByteBuf.java:491) ~[AbstractUnpooledSlicedByteBuf.class:?]

    at io.netty.buffer.AbstractUnpooledSlicedByteBuf.<init>(AbstractUnpooledSlicedByteBuf.java:39) ~[AbstractUnpooledSlicedByteBuf.class:?]

    at io.netty.buffer.UnpooledSlicedByteBuf.<init>(UnpooledSlicedByteBuf.java:24) ~[UnpooledSlicedByteBuf.class:?]

    at io.netty.buffer.AbstractByteBuf.slice(AbstractByteBuf.java:1188) ~[AbstractByteBuf.class:?]

    at io.netty.buffer.AbstractByteBuf.retainedSlice(AbstractByteBuf.java:1193) ~[AbstractByteBuf.class:?]

    at net.minecraft.network.PacketBuffer.retainedSlice(PacketBuffer.java:1214) ~[gy.class:?]

    at com.hbm.core.FMLNetworkHook.fmlProxyPacketToS3FPackets(FMLNetworkHook.java:141) ~[NTM-CE-1.12.2-2.0.0.0.jar:?]

    at com.hbm.core.FMLNetworkHook.networkDispatcherWrite(FMLNetworkHook.java:111) ~[NTM-CE-1.12.2-2.0.0.0.jar:?]

    at net.minecraftforge.fml.common.network.handshake.NetworkDispatcher.write(NetworkDispatcher.java) ~[NetworkDispatcher.class:?]

    at io.netty.channel.AbstractChannelHandlerContext.invokeWrite0(AbstractChannelHandlerContext.java:738) ~[AbstractChannelHandlerContext.class:?]

    at io.netty.channel.AbstractChannelHandlerContext.invokeWriteAndFlush(AbstractChannelHandlerContext.java:801) ~[AbstractChannelHandlerContext.class:?]

    at io.netty.channel.AbstractChannelHandlerContext.write(AbstractChannelHandlerContext.java:814) ~[AbstractChannelHandlerContext.class:?]

    at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:794) ~[AbstractChannelHandlerContext.class:?]

    at io.netty.channel.AbstractChannelHandlerContext.writeAndFlush(AbstractChannelHandlerContext.java:831) ~[AbstractChannelHandlerContext.class:?]

    at io.netty.channel.DefaultChannelPipeline.writeAndFlush(DefaultChannelPipeline.java:1032) ~[DefaultChannelPipeline.class:?]

    at io.netty.channel.AbstractChannel.writeAndFlush(AbstractChannel.java:296) ~[AbstractChannel.class:?]

    at net.minecraft.network.NetworkManager$4.run(NetworkManager.java:245) [gw$4.class:?]

    at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163) [AbstractEventExecutor.class:?]

    at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:403) [SingleThreadEventExecutor.class:?]

    at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:304) [EpollEventLoop.class:?]

    at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:858) [SingleThreadEventExecutor$5.class:?]

    at java.lang.Thread.run(Thread.java:750) [?:1.8.0_472]


 lost connection: Internal Exception: io.netty.util.IllegalReferenceCountException: refCnt: 0
