### PR TITLE
Fix ClassCastException on fake worlds in RadiationSystemNT

### DIFF
--- a/src/main/java/com/hbm/handler/radiation/RadiationSystemNT.java
+++ b/src/main/java/com/hbm/handler/radiation/RadiationSystemNT.java
@@ -429,6 +429,7 @@ public final class RadiationSystemNT {
         }
     }
 
+    @ServerThread
     public static void markSectionForRebuild(World world, BlockPos pos) {
         if (world == null || world.isRemote || !GeneralConfig.advancedRadiation) return;
         if (!(world instanceof WorldServer)) return;


### PR DESCRIPTION
`RadiationSystemNT` accepted `World` but assumed it was always a `WorldServer`.

When HBM blocks are placed in fake worlds such as Advanced Rocketry's AABB scans/fake worlds (`WorldDummy`,)
`BlockNTMGlass.onBlockAdded()` can call `markSectionForRebuild(...)` and crash on the
unconditional cast to `WorldServer`.

This was reproduced during both:
- rocket assembler scans
- rocket structure network reconstruction

Fix: return early when the world is not a `WorldServer`.

This patch adds an early return for non-`WorldServer` worlds. Real server behavior is
unchanged, and fake/dummy worlds do not have meaningful chunk radiation state.