### PR TITLE
OPTIMIZATION!!!

### DIFF
--- a/src/main/java/com/hbm/blocks/machine/MachineBattery.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineBattery.java
@@ -7,6 +7,7 @@ import com.hbm.lib.Library;
 import com.hbm.main.MainRegistry;
 import com.hbm.tileentity.IPersistentNBT;
 import com.hbm.tileentity.machine.TileEntityMachineBattery;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
@@ -178,6 +179,12 @@ public class MachineBattery extends BlockContainer implements ILookOverlay {
 			return 0;
 
         return (int)battery.getPowerRemainingScaled(15L);
+	}
+
+	@Override
+	public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+		TileEntityMachineBattery battery = (TileEntityMachineBattery) world.getTileEntity(pos);
+		battery.isIndirectlyPowered = world.isBlockPowered(pos);
 	}
 
 	@Override

--- a/src/main/java/com/hbm/blocks/machine/MachineFan.java
+++ b/src/main/java/com/hbm/blocks/machine/MachineFan.java
@@ -110,12 +110,19 @@ public class MachineFan extends BlockContainerBakeable implements IToolable, ITo
         public float spin;
         public float prevSpin;
         public boolean falloff = true;
+        private boolean isIndirectlyPowered;
+
+        @Override
+        public void onLoad() {
+            super.onLoad();
+            if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
+        }
 
         @Override
         public void update() {
             this.prevSpin = this.spin;
 
-            if (world.isBlockPowered(pos)) {
+            if (isIndirectlyPowered) {
                 EnumFacing dir = world.getBlockState(pos).getValue(MachineFan.FACING);
 
                 int range = 10;
@@ -218,6 +225,12 @@ public class MachineFan extends BlockContainerBakeable implements IToolable, ITo
         public void deserialize(ByteBuf buf) {
             falloff = buf.readBoolean();
         }
+    }
+
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntityFan fan = (TileEntityFan) world.getTileEntity(pos);
+        fan.isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     @Override

--- a/src/main/java/com/hbm/blocks/network/CraneExtractor.java
+++ b/src/main/java/com/hbm/blocks/network/CraneExtractor.java
@@ -5,6 +5,7 @@ import com.hbm.blocks.ModBlocks;
 import com.hbm.lib.InventoryHelper;
 import com.hbm.tileentity.network.TileEntityCraneBase;
 import com.hbm.tileentity.network.TileEntityCraneExtractor;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -53,6 +54,12 @@ public class CraneExtractor extends BlockCraneBase {
     @Override
     public boolean canConnectRedstone(@NotNull IBlockState state, @NotNull IBlockAccess world, @NotNull BlockPos pos, EnumFacing side) {
         return true;
+    }
+
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntityCraneExtractor crane = (TileEntityCraneExtractor) world.getTileEntity(pos);
+        crane.isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     @Override

--- a/src/main/java/com/hbm/blocks/network/CraneGrabber.java
+++ b/src/main/java/com/hbm/blocks/network/CraneGrabber.java
@@ -5,6 +5,7 @@ import com.hbm.blocks.ModBlocks;
 import com.hbm.lib.InventoryHelper;
 import com.hbm.tileentity.network.TileEntityCraneBase;
 import com.hbm.tileentity.network.TileEntityCraneGrabber;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -45,6 +46,12 @@ public class CraneGrabber extends BlockCraneBase {
     @Override
     public TileEntityCraneBase createNewTileEntity(@NotNull World world, int meta) {
         return new TileEntityCraneGrabber();
+    }
+
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntityCraneGrabber crane = (TileEntityCraneGrabber) world.getTileEntity(pos);
+        crane.isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     @Override

--- a/src/main/java/com/hbm/blocks/network/CraneInserter.java
+++ b/src/main/java/com/hbm/blocks/network/CraneInserter.java
@@ -8,6 +8,7 @@ import com.hbm.blocks.ModBlocks;
 import com.hbm.lib.InventoryHelper;
 import com.hbm.tileentity.network.TileEntityCraneBase;
 import com.hbm.tileentity.network.TileEntityCraneInserter;
+import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.texture.TextureMap;
@@ -99,8 +100,14 @@ public class CraneInserter extends BlockCraneBase implements IEnterableBlock {
         }
     }
 
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntityCraneInserter crane = (TileEntityCraneInserter) world.getTileEntity(pos);
+        crane.isIndirectlyPowered = world.isBlockPowered(pos);
+    }
+
     private static void pushIntoInserter(World world, BlockPos pos, TileEntityCraneInserter inserter, ItemStack toAdd) {
-        if (!world.isBlockPowered(pos)) {
+        if (!inserter.isIndirectlyPowered) {
             EnumFacing outputSide = inserter.getOutputSide();
             TileEntity target = world.getTileEntity(pos.offset(outputSide));
             if (target != null) {

--- a/src/main/java/com/hbm/blocks/network/FluidDuctGauge.java
+++ b/src/main/java/com/hbm/blocks/network/FluidDuctGauge.java
@@ -14,6 +14,7 @@ import com.hbm.inventory.fluid.Fluids;
 import com.hbm.items.IDynamicModels;
 import com.hbm.render.model.BakedModelTransforms;
 import com.hbm.tileentity.network.TileEntityPipeBaseNT;
+import com.hbm.util.ExponentialMovingAverage;
 import com.hbm.util.I18nUtil;
 import com.hbm.world.gen.nbt.INBTBlockTransformable;
 import io.netty.buffer.ByteBuf;
@@ -165,7 +166,7 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
         List<String> text = new ArrayList<>();
         text.add("&[" + duct.getType().getColor() + "&]" + duct.getType().getLocalizedName());
         text.add(String.format(Locale.US, "%,d", duct.deltaTick) + " mB/t");
-        text.add(String.format(Locale.US, "%,d", duct.deltaLastSecond) + " mB/s");
+        text.add(String.format(Locale.US, "%,d", duct.lastSecond) + " mB/s");
         ILookOverlay.printGeneric(event, I18nUtil.resolveKey(getTranslationKey() + ".name"), 0xFFFF00, 0x404000, text);
     }
 
@@ -215,7 +216,8 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
 
         private long deltaTick = 0;
         private long deltaSecond = 0;
-        private long deltaLastSecond = 0;
+        private long lastSecond = 0;
+        private final ExponentialMovingAverage secondEMA = new ExponentialMovingAverage(0.05);
 
         @Override
         public void update() {
@@ -225,7 +227,7 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
                 if (node != null && node.net != null && getType() != Fluids.NONE) {
                     deltaTick = node.net.fluidTracker;
                     if (world.getTotalWorldTime() % 20L == 0) {
-                        deltaLastSecond = deltaSecond;
+                        secondEMA.next(this.lastSecond = this.deltaSecond);
                         deltaSecond = 0;
                     }
                     deltaSecond += deltaTick;
@@ -237,13 +239,13 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
         @Override
         public void serialize(ByteBuf buf) {
             buf.writeLong(deltaTick);
-            buf.writeLong(deltaLastSecond);
+            buf.writeLong(secondEMA.getValue());
         }
 
         @Override
         public void deserialize(ByteBuf buf) {
             deltaTick = Math.max(buf.readLong(), 0);
-            deltaLastSecond = Math.max(buf.readLong(), 0);
+            lastSecond = Math.max(buf.readLong(), 0);
         }
 
         @Optional.Method(modid = "opencomputers")
@@ -254,7 +256,7 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
         @Callback(direct = true)
         @Optional.Method(modid = "opencomputers")
         public Object[] getTransfer(Context context, Arguments args) {
-            return new Object[]{deltaTick, deltaLastSecond};
+            return new Object[]{deltaTick, lastSecond};
         }
 
         @Callback(direct = true)
@@ -266,7 +268,7 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
         @Callback(direct = true)
         @Optional.Method(modid = "opencomputers")
         public Object[] getInfo(Context context, Arguments args) {
-            return new Object[]{deltaTick, deltaLastSecond, getType().getName(), pos.getX(), pos.getY(), pos.getZ()};
+            return new Object[]{deltaTick, lastSecond, getType().getName(), pos.getX(), pos.getY(), pos.getZ()};
         }
 
         @Override
@@ -277,7 +279,7 @@ public class FluidDuctGauge extends FluidDuctBase implements ILookOverlay, ITool
         @Override
         public String provideRORValue(String name) {
             if ((PREFIX_VALUE + "deltatick").equals(name)) return "" + deltaTick;
-            if ((PREFIX_VALUE + "deltasecond").equals(name)) return "" + deltaLastSecond;
+            if ((PREFIX_VALUE + "deltasecond").equals(name)) return "" + lastSecond;
             return null;
         }
     }

--- a/src/main/java/com/hbm/blocks/network/PneumoTube.java
+++ b/src/main/java/com/hbm/blocks/network/PneumoTube.java
@@ -14,6 +14,7 @@ import com.hbm.tileentity.network.TileEntityPneumoTube;
 import com.hbm.util.Compat;
 import com.hbm.util.UnlistedPropertyInteger;
 import mcp.MethodsReturnNonnullByDefault;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.properties.IProperty;
@@ -266,6 +267,12 @@ public class PneumoTube extends BlockContainer implements IToolable, ITooltipPro
     @Override
     public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, IBlockAccess worldIn, BlockPos pos) {
         return getBoundingBox(blockState, worldIn, pos);
+    }
+
+    @Override
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        TileEntityPneumoTube tube = (TileEntityPneumoTube) world.getTileEntity(pos);
+        tube.isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     public boolean canConnectTo(IBlockAccess world, BlockPos pos, ForgeDirection dir) {

--- a/src/main/java/com/hbm/blocks/network/energy/CableDiode.java
+++ b/src/main/java/com/hbm/blocks/network/energy/CableDiode.java
@@ -39,8 +39,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.NetworkManager;
-import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
@@ -277,28 +275,6 @@ public class CableDiode extends BlockContainer implements IEnergyConnectorBlock,
             nbt.setInteger("level", level);
             nbt.setByte("p", (byte) this.priority.ordinal());
             return super.writeToNBT(nbt);
-        }
-
-        @Override
-        public @Nullable SPacketUpdateTileEntity getUpdatePacket() {
-            NBTTagCompound nbt = new NBTTagCompound();
-            this.writeToNBT(nbt);
-            return new SPacketUpdateTileEntity(this.pos, 0, nbt);
-        }
-
-        @Override
-        public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity pkt) {
-            this.readFromNBT(pkt.getNbtCompound());
-        }
-
-        @Override
-        public NBTTagCompound getUpdateTag() {
-            return this.writeToNBT(new NBTTagCompound());
-        }
-
-        @Override
-        public void handleUpdateTag(NBTTagCompound tag) {
-            this.readFromNBT(tag);
         }
 
         private ForgeDirection getDir() {

--- a/src/main/java/com/hbm/tileentity/TileEntityLoadedBase.java
+++ b/src/main/java/com/hbm/tileentity/TileEntityLoadedBase.java
@@ -6,112 +6,183 @@ import com.hbm.lib.Library;
 import com.hbm.packet.toclient.BufPacket;
 import com.hbm.sound.AudioWrapper;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.network.NetworkManager;
+import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.fml.common.network.NetworkRegistry;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nullable;
+
 public class TileEntityLoadedBase extends TileEntity implements ILoadedTile, IBufPacketReceiver {
-	
-	public boolean isLoaded = true;
-	public boolean muffled = false;
 
-	/**
-	 * @return if the tileEntity is loaded. Note that even if it's loaded, it may be invalid!
-	 */
-	@Override
-	public boolean isLoaded() {
-		return isLoaded;
-	}
+    public boolean isLoaded = true;
+    public boolean muffled = false;
 
-	@Override
-	public void onLoad() {
-		super.onLoad();
-		isLoaded = true;
-	}
+    protected boolean hasDataChanged = true;
+    private long lastPackedBufHash = 0L;
 
-	@Override
-	public void onChunkUnload() {
-		super.onChunkUnload();
-		isLoaded = false;
-	}
-
-    /** The "chunks is modified, pls don't forget to save me" effect of markDirty, minus the block updates */
-    public void markChanged() {
-        this.world.markChunkDirty(this.pos, this);
+    /**
+     * @return if the tileEntity is loaded. Note that even if it's loaded, it may be invalid!
+     */
+    @Override
+    public boolean isLoaded() {
+        return isLoaded;
     }
 
-	public AudioWrapper createAudioLoop() { return null; } //Vidarin: Remember to override this if you use rebootAudio!!
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        isLoaded = true;
+    }
 
-	public AudioWrapper rebootAudio(AudioWrapper wrapper) {
-		wrapper.stopSound();
-		AudioWrapper audio = createAudioLoop();
-		audio.startSound();
-		return audio;
-	}
+    @Override
+    public void onChunkUnload() {
+        super.onChunkUnload();
+        isLoaded = false;
+    }
 
-	@Override
-	public void readFromNBT(NBTTagCompound nbt) {
-		super.readFromNBT(nbt);
-		this.muffled = nbt.getBoolean("muffled");
-	}
+    /**
+     * The "chunks is modified, pls don't forget to save me" effect of markDirty, minus the block updates
+     */
+    public void markChanged() {
+        world.markChunkDirty(pos, this);
+    }
 
-	@Override
-	public @NotNull NBTTagCompound writeToNBT(NBTTagCompound nbt) {
-		nbt.setBoolean("muffled", muffled);
-		return super.writeToNBT(nbt);
-	}
+    public AudioWrapper createAudioLoop() {
+        return null;
+    } //Vidarin: Remember to override this if you use rebootAudio!!
 
-	public float getVolume(float baseVolume) {
-		return muffled ? baseVolume * 0.1F : baseVolume;
-	}
-	private long lastPackedBufHash = 0L;
+    public AudioWrapper rebootAudio(AudioWrapper wrapper) {
+        wrapper.stopSound();
+        AudioWrapper audio = createAudioLoop();
+        audio.startSound();
+        return audio;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 * only call super.serialize() on noisy machines. It has no effect on others.<br>
-	 * The final ByteBuf is compared with previous packets sent in order to avoid unnecessary traffic.<br>
+    @Override
+    public void readFromNBT(NBTTagCompound nbt) {
+        super.readFromNBT(nbt);
+        muffled = nbt.getBoolean("muffled");
+        hasDataChanged = true;
+    }
+
+    @Override
+    public NBTTagCompound writeToNBT(NBTTagCompound nbt) {
+        nbt.setBoolean("muffled", muffled);
+        return super.writeToNBT(nbt);
+    }
+
+    public float getVolume(float baseVolume) {
+        return muffled ? baseVolume * 0.1F : baseVolume;
+    }
+
+    public void setMuffled(boolean muffled) {
+        this.muffled = muffled;
+        dataChanged();
+    }
+
+    public void dataChanged() {
+        hasDataChanged = true;
+    }
+
+    @Override
+    public NBTTagCompound getUpdateTag() {
+        NBTTagCompound tag = super.getUpdateTag();
+        ByteBuf buf = Unpooled.buffer();
+        try {
+            serialize(buf);
+            byte[] bytes = new byte[buf.readableBytes()];
+            buf.readBytes(bytes);
+            tag.setByteArray("hbmSync", bytes);
+        } finally {
+            buf.release();
+        }
+        return tag;
+    }
+
+    @Override
+    public void handleUpdateTag(@NotNull NBTTagCompound tag) {
+        super.handleUpdateTag(tag);
+        if (tag.hasKey("hbmSync")) {
+            ByteBuf buf = Unpooled.wrappedBuffer(tag.getByteArray("hbmSync"));
+            deserialize(buf);
+        }
+    }
+
+    @Nullable
+    @Override
+    public SPacketUpdateTileEntity getUpdatePacket() {
+        return new SPacketUpdateTileEntity(pos, 0, getUpdateTag());
+    }
+
+    @Override
+    public void onDataPacket(NetworkManager net, SPacketUpdateTileEntity pkt) {
+        handleUpdateTag(pkt.getNbtCompound());
+    }
+
+    /**
+     * {@inheritDoc}
+     * only call super.serialize() on noisy machines. It has no effect on others.<br>
+     * The final ByteBuf is compared with previous packets sent in order to avoid unnecessary traffic.<br>
      * A side effect of this is that compilation effectively runs on server thread, instead of PacketThreading IO thread;
      * Override {@link #networkPackNT(int)} if this behavior is undesirable.
-	 */
-	@Override
-	public void serialize(ByteBuf buf) {
-		buf.writeBoolean(muffled);
-	}
+     */
+    @Override
+    public void serialize(ByteBuf buf) {
+        buf.writeBoolean(muffled);
+    }
 
-	/**
-	 * {@inheritDoc}
-	 * only call super.deserialize() on noisy machines. It has no effect on others.<br>
-	 * This happens on the <strong>Netty Client IO thread</strong>!
-	 * Direct List modification is guaranteed to produce a CME.<br>
-	 */
-	@Override
-	public void deserialize(ByteBuf buf) {
-		this.muffled = buf.readBoolean();
-	}
+    /**
+     * {@inheritDoc}
+     * only call super.deserialize() on noisy machines. It has no effect on others.<br>
+     * This happens on the <strong>Netty Client IO thread</strong>!
+     * Direct List modification is guaranteed to produce a CME.<br>
+     */
+    @Override
+    public void deserialize(ByteBuf buf) {
+        muffled = buf.readBoolean();
+    }
 
-	/** Sends a sync packet that uses ByteBuf for efficient information-cramming */
+    /**
+     * Sends a sync packet that uses ByteBuf for efficient information-cramming
+     */
     public void networkPackNT(int range) {
         if (world.isRemote) return;
 
         BufPacket packet = new BufPacket(pos.getX(), pos.getY(), pos.getZ(), this);
         ByteBuf preBuf = packet.getCompiledBuffer();
 
-        // Don't send unnecessary packets, except for maybe one every second or so.
-        // If we stop sending duplicate packets entirely, this causes issues when
-        // a client unloads and then loads back a chunk with an unchanged tile entity.
-        // For that client, the tile entity will appear default until anything changes about it.
-        // In my testing, this can be reliably reproduced with a full fluid barrel, for instance.
-        // I think it might be fixable by doing something with getDescriptionPacket() and onDataPacket(),
-        // but this sidesteps the problem for the mean time.
         long preHash = Library.fnv1a64(preBuf);
         if (preHash == lastPackedBufHash) {
-            if (this.world.getTotalWorldTime() % 20 != 0) {
-                packet.releaseBuffer();
-                return;
-            }
+            packet.releaseBuffer();
+            return;
         }
+
         lastPackedBufHash = preHash;
-        PacketThreading.createAllAroundThreadedPacket(packet, new NetworkRegistry.TargetPoint(this.world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(), range));
+        PacketThreading.createAllAroundThreadedPacket(packet,
+                new NetworkRegistry.TargetPoint(world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(),
+                        range));
     }
+
+    /**
+     * Sends a sync packet, skipping compilation entirely when data has not changed.
+     * <p>
+     * TEs using this must call {@link #dataChanged()} whenever any synced field changes.
+     * Failing to do so will cause clients to never receive the update.
+     */
+    public void networkPackMK2(int range) {
+        if (world.isRemote) return;
+
+        if (!hasDataChanged) return;
+
+        BufPacket packet = new BufPacket(pos.getX(), pos.getY(), pos.getZ(), this);
+        PacketThreading.createAllAroundThreadedPacket(packet,
+                new NetworkRegistry.TargetPoint(world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(),
+                        range));
+        hasDataChanged = false;
+    }
+
 }

--- a/src/main/java/com/hbm/tileentity/TileEntityProxyCombo.java
+++ b/src/main/java/com/hbm/tileentity/TileEntityProxyCombo.java
@@ -21,7 +21,6 @@ import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Context;
 import li.cil.oc.api.network.SimpleComponent;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.network.play.server.SPacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -50,6 +49,7 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
     // due to some issues with OC deciding that it's gonna call the component name function before the worldObj is loaded
     // the component name must be cached to prevent it from shitting itself
     String componentName = CompatHandler.nullComponent;
+    boolean supportsOC;
 
     boolean heat;
 
@@ -107,6 +107,7 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
     public TileEntity getTile() {
         if (tile == null || tile.isInvalid() || (tile instanceof TileEntityLoadedBase && !((TileEntityLoadedBase) tile).isLoaded)) {
             tile = this.getTE();
+            supportsOC = tile instanceof CompatHandler.OCComponent;
         }
         return tile;
     }
@@ -410,27 +411,13 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
         return null;
     }
 
-    @Override
-    public @NotNull NBTTagCompound getUpdateTag() {
-        return writeToNBT(new NBTTagCompound());
-    }
-
-    @Override
-    public SPacketUpdateTileEntity getUpdatePacket() {
-        return new SPacketUpdateTileEntity(pos, 0, getUpdateTag());
-    }
-
-    @Override
-    public void handleUpdateTag(@NotNull NBTTagCompound tag) {
-        this.readFromNBT(tag);
-    }
-
     @Override // please work
     @Optional.Method(modid = "OpenComputers")
     public String getComponentName() {
         if(this.world == null) // OC is going too fast, grab from NBT!
             return componentName;
-        if(this.getCoreObject() instanceof CompatHandler.OCComponent) {
+        getTile(); // ensure supportsOC is initialized
+        if(supportsOC) {
             if (componentName == null || componentName.equals(CompatHandler.OCComponent.super.getComponentName())) {
                 componentName = ((CompatHandler.OCComponent) this.getCoreObject()).getComponentName();
             }
@@ -442,7 +429,8 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
     @Override
     @Optional.Method(modid = "opencomputers")
     public boolean canConnectNode(EnumFacing side) {
-        if(this.getCoreObject() instanceof CompatHandler.OCComponent) {
+        getTile();
+        if(supportsOC) {
             boolean isComponent = false;
             if (this.world != null) {
                 Object nodeTE = Compat.getTileStandard(this.world, this.pos.getX() + side.getXOffset(), this.pos.getY() + side.getYOffset(), this.pos.getZ() + side.getZOffset());
@@ -463,7 +451,8 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
     @Override
     @Optional.Method(modid = "opencomputers")
     public String[] methods() {
-        if(this.getCoreObject() instanceof CompatHandler.OCComponent)
+        getTile();
+        if(supportsOC)
             return ((CompatHandler.OCComponent) this.getCoreObject()).methods();
         return CompatHandler.OCComponent.super.methods();
     }
@@ -471,7 +460,8 @@ public class TileEntityProxyCombo extends TileEntityProxyBase implements IEnergy
     @Override
     @Optional.Method(modid = "opencomputers")
     public Object[] invoke(String method, Context context, Arguments args) throws Exception {
-        if(this.getCoreObject() instanceof CompatHandler.OCComponent)
+        getTile();
+        if(supportsOC)
             return ((CompatHandler.OCComponent) this.getCoreObject()).invoke(method, context, args);
         return CompatHandler.OCComponent.super.invoke(null, null, null);
     }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnaceRTG.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityDiFurnaceRTG.java
@@ -199,8 +199,6 @@ public class TileEntityDiFurnaceRTG extends TileEntityMachineBase implements ITi
             if (new1.getCount() <= 0) new1 = ItemStack.EMPTY;
             inventory.setStackInSlot(1, new1);
         }
-
-        this.markDirty();
     }
 
     public boolean hasPower() {

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityLockableBase.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityLockableBase.java
@@ -2,30 +2,24 @@ package com.hbm.tileentity.machine;
 
 import com.hbm.api.block.IToolable.ToolType;
 import com.hbm.handler.ArmorUtil;
-import com.hbm.handler.threading.PacketThreading;
 import com.hbm.items.ModItems;
 import com.hbm.items.tool.ItemKeyPin;
 import com.hbm.items.tool.ItemTooling;
 import com.hbm.lib.HBMSoundHandler;
-import com.hbm.lib.Library;
 import com.hbm.main.MainRegistry;
-import com.hbm.packet.toclient.BufPacket;
-import com.hbm.tileentity.IBufPacketReceiver;
+import com.hbm.tileentity.TileEntityLoadedBase;
 import io.netty.buffer.ByteBuf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.EnumHand;
 import net.minecraft.util.SoundCategory;
-import net.minecraftforge.fml.common.network.NetworkRegistry;
 
-public class TileEntityLockableBase extends TileEntity implements IBufPacketReceiver {
+public abstract class TileEntityLockableBase extends TileEntityLoadedBase {
     protected int lock;
     private boolean isLocked = false;
     protected double lockMod = 0.1D;
-    private long lastPackedBufHash = 0L;
 
     public boolean isLocked() {
         return isLocked;
@@ -39,15 +33,19 @@ public class TileEntityLockableBase extends TileEntity implements IBufPacketRece
         if(lock == 0) {
             MainRegistry.logger.error("A block has been set to locked state before setting pins, this should not happen and may cause errors! " + this.toString());
         }
-        if(!isLocked)
+        if(!isLocked) {
+            isLocked = true;
+            dataChanged();
             markDirty();
-        isLocked = true;
+        }
     }
 
     public void setPins(int pins) {
-        if(lock != pins)
+        if(lock != pins) {
+            lock = pins;
+            dataChanged();
             markDirty();
-        lock = pins;
+        }
     }
 
     public int getPins() {
@@ -55,9 +53,11 @@ public class TileEntityLockableBase extends TileEntity implements IBufPacketRece
     }
 
     public void setMod(double mod) {
-        if(lockMod != mod)
+        if(lockMod != mod) {
+            lockMod = mod;
+            dataChanged();
             markDirty();
-        lockMod = mod;
+        }
     }
 
     public double getMod() {
@@ -161,26 +161,17 @@ public class TileEntityLockableBase extends TileEntity implements IBufPacketRece
 
     @Override
     public void serialize(ByteBuf buf) {
+        super.serialize(buf);
+        buf.writeInt(lock);
         buf.writeBoolean(isLocked);
+        buf.writeDouble(lockMod);
     }
 
     @Override
     public void deserialize(ByteBuf buf) {
+        super.deserialize(buf);
+        this.lock = buf.readInt();
         this.isLocked = buf.readBoolean();
-    }
-
-    public void networkPackNT(int range) {
-        if (world.isRemote) return;
-        BufPacket packet = new BufPacket(pos.getX(), pos.getY(), pos.getZ(), this);
-        ByteBuf currentBuf = packet.getCompiledBuffer();
-        long currentHash = Library.fnv1a64(currentBuf);
-        if (currentHash == lastPackedBufHash) {
-            if (this.world.getTotalWorldTime() % 20 != 0) {
-                packet.releaseBuffer();
-                return;
-            }
-        }
-        lastPackedBufHash = currentHash;
-        PacketThreading.createAllAroundThreadedPacket(packet, new NetworkRegistry.TargetPoint(this.world.provider.getDimension(), pos.getX(), pos.getY(), pos.getZ(), range));
+        this.lockMod = buf.readDouble();
     }
 }

--- a/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBattery.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityMachineBattery.java
@@ -65,8 +65,16 @@ public class TileEntityMachineBattery extends TileEntityMachineBase implements I
 
     public byte lastRedstone = 0;
 
+    public boolean isIndirectlyPowered;
+
     public TileEntityMachineBattery() {
         super(4);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     public static ForgeDirection[] getSendDirections() {
@@ -299,8 +307,7 @@ public class TileEntityMachineBattery extends TileEntityMachineBase implements I
 
     public short getRelevantMode(boolean useCache) {
         if (useCache) return this.modeCache;
-        boolean isPowered = world.isBlockPowered(this.pos);
-        this.modeCache = isPowered ? this.redHigh : this.redLow;
+        this.modeCache = isIndirectlyPowered ? this.redHigh : this.redLow;
         return this.modeCache;
     }
 

--- a/src/main/java/com/hbm/tileentity/machine/TileEntitySlidingBlastDoor.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntitySlidingBlastDoor.java
@@ -95,6 +95,7 @@ public class TileEntitySlidingBlastDoor extends TileEntityLockableBase implement
 
     @Override
     public void serialize(ByteBuf buf){
+        super.serialize(buf);
         buf.writeBoolean(shouldUseBB);
         buf.writeByte(state.ordinal());
         if(texture != -1)
@@ -103,6 +104,7 @@ public class TileEntitySlidingBlastDoor extends TileEntityLockableBase implement
 
     @Override
     public void deserialize(ByteBuf buf) {
+        super.deserialize(buf);
         shouldUseBB = buf.readBoolean();
 
         DoorState newState = DoorState.values()[buf.readByte()];

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneExtractor.java
@@ -41,6 +41,7 @@ import org.jetbrains.annotations.NotNull;
 
 @AutoRegister
 public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGUIProvider, IControlReceiver {
+    public boolean isIndirectlyPowered;
     public boolean isWhitelist = false;
     public boolean maxEject = false;
     protected SideConfig sideConfig;
@@ -97,6 +98,12 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
         }
     }
 
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
+    }
+
     public boolean canExtractItemCE(int slot, ItemStack stack, EnumFacing side, ISidedInventory sided) {
         if(isCofhCoreLoaded()) {
             return canExtractItemExtended(slot, side);
@@ -125,7 +132,7 @@ public class TileEntityCraneExtractor extends TileEntityCraneBase implements IGU
                 }
             }
 
-            if(tickCounter >= delay && !this.world.isBlockPowered(pos)) {
+            if(tickCounter >= delay && !isIndirectlyPowered) {
                 tickCounter = 0;
                 int amount = 1;
 

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneGrabber.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneGrabber.java
@@ -35,6 +35,7 @@ import java.util.List;
 
 @AutoRegister
 public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIProvider, IControlReceiver {
+    public boolean isIndirectlyPowered;
     public boolean isWhitelist = false;
     public ModulePatternMatcher matcher;
     private int tickCounter = 0;
@@ -62,6 +63,12 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
     }
 
     @Override
+    public void onLoad() {
+        super.onLoad();
+        if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
+    }
+
+    @Override
     public String getDefaultName() {
         return "container.craneGrabber";
     }
@@ -72,7 +79,7 @@ public class TileEntityCraneGrabber extends TileEntityCraneBase implements IGUIP
         if(!world.isRemote) {
             tickCounter++;
 
-            if(tickCounter >= this.delay && !this.world.isBlockPowered(pos)) {
+            if(tickCounter >= this.delay && !isIndirectlyPowered) {
                 tickCounter = 0;
                 int amount = 1;
                 if(!inventory.getStackInSlot(9).isEmpty()){

--- a/src/main/java/com/hbm/tileentity/network/TileEntityCraneInserter.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityCraneInserter.java
@@ -5,7 +5,6 @@ import com.hbm.interfaces.AutoRegister;
 import com.hbm.inventory.container.ContainerCraneInserter;
 import com.hbm.inventory.gui.GUICraneInserter;
 import com.hbm.tileentity.IGUIProvider;
-import io.netty.buffer.ByteBuf;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -23,10 +22,17 @@ import org.jetbrains.annotations.NotNull;
 
 @AutoRegister
 public class TileEntityCraneInserter extends TileEntityCraneBase implements IGUIProvider, IControlReceiver {
+    public boolean isIndirectlyPowered;
     public boolean destroyer = true;
 
     public TileEntityCraneInserter() {
         super(21);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     @Override
@@ -37,7 +43,7 @@ public class TileEntityCraneInserter extends TileEntityCraneBase implements IGUI
     @Override
     public void update() {
         super.update();
-        if(!world.isRemote && !world.isBlockPowered(pos)) {
+        if(!world.isRemote && !isIndirectlyPowered) {
             tryFillTe();
         }
     }
@@ -133,16 +139,6 @@ public class TileEntityCraneInserter extends TileEntityCraneBase implements IGUI
     @SideOnly(Side.CLIENT)
     public GuiScreen provideGUI(int ID, EntityPlayer player, World world, int x, int y, int z) {
         return new GUICraneInserter(player.inventory, this);
-    }
-
-    @Override
-    public void serialize(ByteBuf buf) {
-        buf.writeBoolean(destroyer);
-    }
-
-    @Override
-    public void deserialize(ByteBuf buf) {
-        this.destroyer = buf.readBoolean();
     }
 
     @Override

--- a/src/main/java/com/hbm/tileentity/network/TileEntityPneumoTube.java
+++ b/src/main/java/com/hbm/tileentity/network/TileEntityPneumoTube.java
@@ -45,6 +45,8 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
     public ForgeDirection insertionDir = ForgeDirection.UNKNOWN;
     public ForgeDirection ejectionDir = ForgeDirection.UNKNOWN;
 
+    public boolean isIndirectlyPowered;
+
     public boolean whitelist = false;
     public boolean redstone = false;
     public byte sendOrder = 0;
@@ -59,6 +61,12 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
     public TileEntityPneumoTube() {
         super(15);
         this.compair = new FluidTankNTM(Fluids.AIR, 4_000).withPressure(1);
+    }
+
+    @Override
+    public void onLoad() {
+        super.onLoad();
+        if(!world.isRemote) isIndirectlyPowered = world.isBlockPowered(pos);
     }
 
     public static int getRangeFromPressure(int pressure) {
@@ -114,7 +122,7 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
             }
         }
 
-        if (this.isCompressor() && (!this.world.isBlockPowered(pos) ^ this.redstone)) {
+        if (this.isCompressor() && (!isIndirectlyPowered ^ this.redstone)) {
 
             int randTime = Math.abs((int) (world.getTotalWorldTime() + getIdentifier(pos)));
 
@@ -153,6 +161,7 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
 
                     if (moved) {
                         this.compair.setFill(this.compair.getFill() - 50);
+                        this.dataChanged();
 
                         if (this.soundDelay <= 0 && !this.muffled) {
                             world.playSound(null,
@@ -181,7 +190,7 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
             }
         }
 
-        this.networkPackNT(15);
+        this.networkPackMK2(15);
     }
 
     @Override
@@ -289,7 +298,6 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
 
         this.whitelist = nbt.getBoolean("whitelist");
         this.redstone = nbt.getBoolean("redstone");
-
         if (world != null && world.isRemote) {
             world.markBlockRangeForRenderUpdate(pos, pos);
         }
@@ -348,6 +356,7 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
             setFilterContents(data);
         }
 
+        this.dataChanged();
         this.markDirty();
     }
 
@@ -369,6 +378,13 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
     @Override
     public FluidTankNTM[] getReceivingTanks() {
         return new FluidTankNTM[]{compair};
+    }
+
+    @Override
+    public long transferFluid(FluidType type, int pressure, long amount) {
+        long remaining = IFluidStandardReceiverMK2.super.transferFluid(type, pressure, amount);
+        if(remaining != amount) dataChanged();
+        return remaining;
     }
 
     @Override
@@ -396,6 +412,7 @@ public class TileEntityPneumoTube extends TileEntityMachineBase implements IGUIP
         this.whitelist = nbt.getBoolean("whitelist");
         this.redstone = nbt.getBoolean("redstone");
 
+        this.dataChanged();
     }
 
     public static class PneumaticNode extends GenNode<PneumaticNetwork> {

--- a/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
+++ b/src/main/java/com/hbm/tileentity/turret/TileEntityTurretBaseNT.java
@@ -58,6 +58,7 @@ import net.minecraftforge.fml.common.Optional;
 import net.minecraftforge.fml.common.network.NetworkRegistry.TargetPoint;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import net.minecraftforge.items.ItemStackHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -117,6 +118,7 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 	public int stattrak;
 	public int casingDelay;
 	protected SpentCasing cachedCasingConfig = null;
+	protected List<String> cachedWhitelist = null;
 
 	/**
 	 * X
@@ -128,6 +130,23 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 
 	public TileEntityTurretBaseNT(){
 		super(11, false, true);
+	}
+
+	@Override
+	protected ItemStackHandler getNewInventory(int scount, int slotlimit) {
+		return new ItemStackHandler(scount) {
+			@Override
+			protected void onContentsChanged(int slot) {
+				super.onContentsChanged(slot);
+				markDirty();
+				if(slot == 0) cachedWhitelist = null;
+			}
+
+			@Override
+			public int getSlotLimit(int slot) {
+				return slotlimit;
+			}
+		};
 	}
 
 	@Override
@@ -386,6 +405,9 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 	 */
 	public List<String> getWhitelist() {
 
+		if(cachedWhitelist != null)
+			return cachedWhitelist;
+
 		if(inventory.getStackInSlot(0).getItem() == ModItems.turret_chip) {
 
 			String[] array = ItemTurretBiometry.getNames(inventory.getStackInSlot(0));
@@ -393,7 +415,7 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 			if(array == null)
 				return null;
 
-			return Arrays.asList(ItemTurretBiometry.getNames(inventory.getStackInSlot(0)));
+			return cachedWhitelist = Arrays.asList(array);
 		}
 
 		return null;
@@ -407,6 +429,7 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 
 		if(inventory.getStackInSlot(0).getItem() == ModItems.turret_chip) {
 			ItemTurretBiometry.addName(inventory.getStackInSlot(0), name);
+			if(cachedWhitelist != null) cachedWhitelist.add(name);
 		}
 	}
 
@@ -430,6 +453,8 @@ public abstract class TileEntityTurretBaseNT extends TileEntityMachineBase imple
 
 			for(String name : names)
 				ItemTurretBiometry.addName(inventory.getStackInSlot(0), name);
+
+			if(cachedWhitelist != null) cachedWhitelist.remove(index);
 		}
 	}
 

--- a/src/main/java/com/hbm/util/ExponentialMovingAverage.java
+++ b/src/main/java/com/hbm/util/ExponentialMovingAverage.java
@@ -1,0 +1,27 @@
+package com.hbm.util;
+
+/**
+ * Calculates a moving average based on inputs provided over time.
+ * @author BallOfEnergy01
+ */
+public class ExponentialMovingAverage {
+
+	private final double alpha;
+	private double ema = -1;
+
+	public ExponentialMovingAverage(double alpha) {
+		this.alpha = alpha;
+	}
+
+	public void next(double value) {
+		if(ema == -1) {
+			ema = value;
+		} else {
+			ema = alpha * value + (1 - alpha) * ema;
+		}
+	}
+
+	public long getValue() {
+		return (long) ema;
+	}
+}


### PR DESCRIPTION
See upstream pr https://github.com/HbmMods/Hbm-s-Nuclear-Tech-GIT/pull/2674
Their approach of a dedicated C2S TEDataRequestPacket is vulnerable.
Instead, we use vanilla's built-in `getUpdateTag()` / `handleUpdateTag()` on `TileEntityLoadedBase`.
When the server sends chunk data to a client, it automatically calls `getUpdateTag()` on every TE and includes the NBT in the chunk packet. Purely server-driven.