### PR TITLE
fix: Crash at GUICoreEmitter

### DIFF
--- a/src/main/java/com/hbm/inventory/gui/GUICoreEmitter.java
+++ b/src/main/java/com/hbm/inventory/gui/GUICoreEmitter.java
@@ -68,7 +68,7 @@ public class GUICoreEmitter extends GuiInfoContainer {
     	if(guiLeft + 124 <= x && guiLeft + 124 + 18 > x && guiTop + 56 < y && guiTop + 56 + 18 >= y) {
     		
     		if(saveButtonCoolDown == 0 && NumberUtils.isCreatable(field.getText())) {
-    			int j = MathHelper.clamp(Integer.parseInt(field.getText()), 1, 100);
+    			int j = MathHelper.clamp((int)  Float.parseFloat(field.getText()), 1, 100);
     			field.setText(j + "");
 				playClickSound();
 	    		PacketDispatcher.wrapper.sendToServer(new AuxButtonPacket(emitter.getPos(), j, 0));


### PR DESCRIPTION
this fixes a bug that would crash the client if a float was inputted into the text input of DFC emitter's gui