### PR TITLE
fix: old compat code crash with ModernSplash

### DIFF
--- a/src/main/java/com/hbm/main/ResourceManager.java
+++ b/src/main/java/com/hbm/main/ResourceManager.java
@@ -1595,16 +1595,7 @@ public class ResourceManager {
     });
 
     static {
-        Class<?> splash;
-        if (Loader.isModLoaded(Compat.ModIds.MODERN_SPLASH)) {
-            try {
-                splash = Class.forName("gkappa.modernsplash.CustomSplash");
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("ModernSplash loaded but failed to find gkappa.modernsplash.CustomSplash", e);
-            }
-        } else {
-            splash = SplashProgress.class;
-        }
+        Class<?> splash = SplashProgress.class;
         splashThreadGetter = MethodHandleHelper.findStaticGetter(splash, "thread", Thread.class);
         splashEnabledGetter = MethodHandleHelper.findStaticGetter(splash, "enabled", boolean.class);
         splashPauseHandle = MethodHandleHelper.findStatic(splash, "pause", MethodType.methodType(void.class));

--- a/src/main/java/com/hbm/util/Compat.java
+++ b/src/main/java/com/hbm/util/Compat.java
@@ -113,7 +113,6 @@ public class Compat {
         public static final String OPEN_COMPUTERS = "opencomputers";
         public static final String CTM = "ctm";
         public static final String AE2 = "appliedenergistics2";
-        public static final String MODERN_SPLASH = "modernsplash";
         public static final String HBM_NTM_STRUCTURE = "ntmdopolnenie"; //Yes, this is the modid. Idk what this means
         public static final String POTATOO_STRUCTURE = "potatooscustomstructureforhbm"; //Can we just block all mccreator mods?
         public static final String HBM_NTM_LUCKY_BLOCKS = "luckynuke"; //It's all fucking garbage;


### PR DESCRIPTION
ModernSplash 1.5.0+ now switched to replacing SplashProgress by ASM, accessing through `CustomSplash` is useless and crashed the game.
This PR removed the compat and just use the forge class. Tested against ModerSplash 1.5.1.
(1.5.1 added back the `enabled` field, so the reflection doesn't crash like 1.5.0)