### PR TITLE
Add coreHeatCapacity to getHeat method return values

### DIFF
--- a/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
+++ b/src/main/java/com/hbm/tileentity/machine/TileEntityPWRController.java
@@ -620,7 +620,7 @@ public class TileEntityPWRController extends TileEntityMachineBase implements IT
     @Callback(direct = true)
     @Optional.Method(modid = "opencomputers")
     public Object[] getHeat(Context context, Arguments args) {
-        return new Object[]{coreHeat, hullHeat};
+        return new Object[]{coreHeat, hullHeat, coreHeatCapacity};
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
the lua script for PWRangler errors and after consulting CoPilot for about an hour, I figured out what the problem was:

The heat capacity was not being exposed at all in the method

this should fix it